### PR TITLE
Fix: refactor address modal component

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,17 @@
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+.caret-blink {
+  display: inline-block;
+  width: 2px;
+  height: 0.9em;
+  background-color: currentColor;
+  margin-left: 2px;
+  vertical-align: middle;
+  animation: blink 1s step-start infinite;
+}
+
 /* Custom horizontal scrollbar for PackageTypeModal */
 .custom-scrollbar::-webkit-scrollbar {
   height: 8px;

--- a/src/pages/home/components/FormHorizontalBar.tsx
+++ b/src/pages/home/components/FormHorizontalBar.tsx
@@ -169,6 +169,9 @@ const FormHorizontalBar = ({
   }, [activeMode, isDashboard]);
 
   // Modal states for Direct mode
+  const [activeCard, setActiveCard] = useState<"pickup" | "destination" | null>(
+    "pickup",
+  );
   const [pickupModalOpen, setPickupModalOpen] = useState(false);
   const [destinationModalOpen, setDestinationModalOpen] = useState(false);
   const [packageModalOpen, setPackageModalOpen] = useState(false);
@@ -235,9 +238,7 @@ const FormHorizontalBar = ({
       .string({ required_error: "Weight is required" })
       .min(1, { message: "Enter weight" }),
     dimensions: z.string().optional(),
-    itemPrice: z
-      .string({ required_error: "Item price is required" })
-      .min(1, { message: "Enter item price" }),
+    itemPrice: z.string().optional(),
     pickupDate: z.string().optional(),
   });
 
@@ -341,7 +342,7 @@ const FormHorizontalBar = ({
         {
           ...parsed,
           quantity: 1,
-          itemValue: Number(parsed.itemPrice),
+          itemValue: Number(parsed.itemPrice) || 0,
           packageDescription: {
             isFragile: false,
             isPerishable: false,
@@ -377,9 +378,7 @@ const FormHorizontalBar = ({
       ? "w-full max-w-3xl mx-auto py-10 px-6 rounded-2xl bg-white border relative"
       : "w-full mx-auto max-w-[354px] lg:max-w-[1024px] pt-[12.82px] px-[10.82px] pb-[0.83px] lg:pt-[16.57px] lg:px-[16.57px] lg:pb-[16.57px] rounded-[32px] lg:rounded-[40px] border-t border-[#F1F5F9] bg-white/80 backdrop-blur-[48px] shadow-lg",
     !isDashboard && variant === "bold" && "bg-white border",
-    !isDashboard &&
-      variant === "minimal" &&
-      "bg-white border border-gray-200",
+    !isDashboard && variant === "minimal" && "bg-white border border-gray-200",
     !isDashboard && variant === "floating" && "bg-white",
   );
 
@@ -469,7 +468,8 @@ const FormHorizontalBar = ({
         aria-hidden="true"
         className="pointer-events-none absolute -inset-4 rounded-[48px] lg:rounded-[56px] 
                   bg-[linear-gradient(90deg,#A4F4CF_0%,#DCFCE7_50%,#CBFBF1_100%)]
-                  blur-[40px] opacity-50 z-0 translate-y-5"></div>
+                  blur-[40px] opacity-50 z-0 translate-y-5"
+      ></div>
       <div className={cn(containerStyles, "relative z-10")}>
         {isDashboard && (
           <div className="absolute left-1/2 transform -translate-x-1/2 top-[-39px]">
@@ -546,8 +546,17 @@ const FormHorizontalBar = ({
             <div className={containerClass}>
               {/* Pickup Location - Modal Trigger */}
               <div
-                onClick={() => setPickupModalOpen(true)}
-                className={cn("direct-send", isDashboard && "mt-4 w-full!")}
+                onClick={() => {
+                  setActiveCard("pickup");
+                  setPickupModalOpen(true);
+                }}
+                className={cn(
+                  "direct-send",
+                  isDashboard && "mt-4 w-full!",
+                  activeCard === "pickup" &&
+                    !pickupLocation &&
+                    "ring-2 ring-brand/40",
+                )}
               >
                 <label
                   className={cn(
@@ -560,22 +569,27 @@ const FormHorizontalBar = ({
                   </p>
                   <div className="border-2 border-[#CAD5E2] p-1 rounded-full w-4 h-4"></div>
                 </label>
-               
+
                 <div className="w-full flex items-center justify-between">
                   <span
                     className={cn(
-                      "text-base truncate",
+                      "text-base truncate flex items-center",
                       pickupLocation ? "text-[#1a1a1a]" : "text-[#9ca3af]",
                     )}
                   >
-                    {pickupLocation || (
+                    {pickupLocation ? (
+                      pickupLocation
+                    ) : (
                       <>
                         <span className="lg:hidden font-arial font-bold text-sm">
                           Enter address
                         </span>
-                        <span className="hidden lg:block font-arial">
+                        <span className="hidden lg:inline font-arial">
                           Where from
                         </span>
+                        {activeCard === "pickup" && (
+                          <span className="caret-blink" />
+                        )}
                       </>
                     )}
                   </span>
@@ -590,7 +604,10 @@ const FormHorizontalBar = ({
               {/* Destination - Modal Trigger */}
               <div
                 className={cn("direct-send", isDashboard && "w-full!")}
-                onClick={() => setDestinationModalOpen(true)}
+                onClick={() => {
+                  setActiveCard("destination");
+                  setDestinationModalOpen(true);
+                }}
               >
                 <label
                   className={cn(
@@ -606,9 +623,7 @@ const FormHorizontalBar = ({
                   </p>
 
                   <div className="border-2 border-[#CAD5E2] p-1 rounded-full w-4 h-4"></div>
-                  
                 </label>
-               
 
                 <div className="w-full flex items-center justify-between">
                   <span
@@ -655,9 +670,12 @@ const FormHorizontalBar = ({
                 </label>
                 <div className="w-full flex items-center justify-between -mt-1">
                   {packageName ? (
-                    <span className="text-base truncate text-[#1a1a1a]">
-                      {packageName}
-                    </span>
+                    <>
+                      <span className="text-base truncate text-[#1a1a1a]">
+                        {packageName}
+                      </span>
+                      <FaAngleDown size={18} className="text-[#CAD5E2]" />
+                    </>
                   ) : (
                     <>
                       <span className="font-arial text-sm lg:text-base font-bold text-[#9ca3af]">
@@ -722,7 +740,9 @@ const FormHorizontalBar = ({
               </div>
 
               {/* Buttons */}
-              <div className={isDashboard ? "mt-4 w-full" : "flex gap-3 items-end"}>
+              <div
+                className={isDashboard ? "mt-4 w-full" : "flex gap-3 items-end"}
+              >
                 <Button
                   type="button"
                   size={"custom"}
@@ -761,7 +781,7 @@ const FormHorizontalBar = ({
                       data: [
                         {
                           ...data,
-                          itemValue: Number(data.itemPrice),
+                          itemValue: Number(data.itemPrice) || 0,
                           quantity: 1,
                           packageDescription: {
                             isFragile: false,
@@ -792,8 +812,17 @@ const FormHorizontalBar = ({
             <div className={compareContainerClass}>
               {/* Pickup Location - Modal Trigger */}
               <div
-                className={cn("compare-pickup-from cursor-pointer", isDashboard && "mt-4 w-full!")}
-                onClick={() => setPickupModalOpen(true)}
+                className={cn(
+                  "compare-pickup-from cursor-pointer",
+                  isDashboard && "mt-4 w-full!",
+                  activeCard === "pickup" &&
+                    !pickupLocation &&
+                    "ring-2 ring-brand/40",
+                )}
+                onClick={() => {
+                  setActiveCard("pickup");
+                  setPickupModalOpen(true);
+                }}
               >
                 <label
                   className={cn(
@@ -809,18 +838,23 @@ const FormHorizontalBar = ({
                 <div className="w-full flex items-center justify-between">
                   <span
                     className={cn(
-                      "text-base truncate",
+                      "text-base truncate flex items-center",
                       pickupLocation ? "text-[#1a1a1a]" : "text-[#9ca3af]",
                     )}
                   >
-                    {pickupLocation || (
+                    {pickupLocation ? (
+                      pickupLocation
+                    ) : (
                       <>
                         <span className="lg:hidden font-arial font-bold text-sm">
                           Enter Address
                         </span>
-                        <span className="hidden lg:block text-[#CAD5E2] font-arial font-bold">
+                        <span className="hidden lg:inline text-[#CAD5E2] font-arial font-bold">
                           Enter Address
                         </span>
+                        {activeCard === "pickup" && (
+                          <span className="caret-blink" />
+                        )}
                       </>
                     )}
                   </span>
@@ -834,8 +868,14 @@ const FormHorizontalBar = ({
 
               {/* Destination - Modal Trigger */}
               <div
-                className={cn("compare-pickup-destination", isDashboard && "!w-full")}
-                onClick={() => setDestinationModalOpen(true)}
+                className={cn(
+                  "compare-pickup-destination",
+                  isDashboard && "!w-full",
+                )}
+                onClick={() => {
+                  setActiveCard("destination");
+                  setDestinationModalOpen(true);
+                }}
               >
                 <label
                   className={cn(
@@ -895,24 +935,27 @@ const FormHorizontalBar = ({
 
                   <FiPackage size={18} className="text-[#CAD5E2]" />
                 </label>
-                <div className="w-full flex flex-col items-start justify-between">
+                <div className="w-full flex flex-col items-start  justify-between">
                   {packageName && weight && dimensions ? (
-                    <div className="flex flex-col items-start space-y-0.5">
-                      <span className="text-xs truncate text-[#1a1a1a] font-semibold">
-                        {packageName}
-                      </span>
-                      <span className="text-xs text-gray-600 truncate">
-                        {dimensions} • {weight}
-                        {selectedPackageData?.weightUnit || "kg"}
-                      </span>
+                    <div className="w-full flex items-center justify-between ">
+                      <div className="flex flex-col items-start space-y-0.5">
+                        <span className="text-xs truncate text-[#1a1a1a] font-semibold">
+                          {packageName}
+                        </span>
+                        <span className="text-xs text-gray-600 truncate">
+                          {dimensions} • {weight}
+                          {selectedPackageData?.weightUnit || "kg"}
+                        </span>
+                      </div>
+                      <FaAngleDown size={18} className="text-[#CAD5E2]" />
                     </div>
                   ) : (
-                    <>
+                    <div className="w-full flex items-center justify-between">
                       <span className="font-arial text-sm lg:text-base text-[#9ca3af] font-bold">
                         Select
                       </span>
                       <FaAngleDown size={18} className="text-[#CAD5E2]" />
-                    </>
+                    </div>
                   )}
                 </div>
 
@@ -924,7 +967,9 @@ const FormHorizontalBar = ({
               </div>
 
               {/* Compare Button */}
-              <div className={isDashboard ? "mt-4 w-full" : "flex gap-3 items-end"}>
+              <div
+                className={isDashboard ? "mt-4 w-full" : "flex gap-3 items-end"}
+              >
                 <Button
                   type="button"
                   size={"custom"}
@@ -942,7 +987,7 @@ const FormHorizontalBar = ({
                       data: [
                         {
                           ...data,
-                          itemValue: Number(data.itemPrice),
+                          itemValue: Number(data.itemPrice) || 0,
                           quantity: 1,
                           packageDescription: {
                             isFragile: false,

--- a/src/pages/home/components/modals/AddressModal.tsx
+++ b/src/pages/home/components/modals/AddressModal.tsx
@@ -223,6 +223,7 @@ export function AddressModal({
 }: AddressModalProps) {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [searchValue, setSearchValue] = useState("");
+  const [showExtraFields, setShowExtraFields] = useState(false);
   const [manualAddress, setManualAddress] = useState<ManualAddressData>({
     street: "",
     apartment: "",
@@ -248,6 +249,7 @@ export function AddressModal({
   useEffect(() => {
     if (open && value) {
       setManualAddress(parseAddressFields(value));
+      setShowExtraFields(true);
     } else if (open && !value) {
       // Reset to blank when opening without a value
       setManualAddress({
@@ -256,6 +258,7 @@ export function AddressModal({
         city: "",
         state: "",
       });
+      setShowExtraFields(false);
     }
   }, [open, value]);
 
@@ -265,6 +268,7 @@ export function AddressModal({
    */
   const parseAddressComponents = (
     components: google.maps.GeocoderAddressComponent[],
+    placeName?: string,
   ): Partial<ManualAddressData> => {
     let premise = "";
     let streetNumber = "";
@@ -317,13 +321,25 @@ export function AddressModal({
 
     // Build full street address from all relevant components
     const streetParts = [];
-    if (premise) streetParts.push(premise);
-    if (streetNumber && route) {
-      streetParts.push(`${streetNumber} ${route}`);
-    } else if (route) {
-      streetParts.push(route);
-    } else if (streetNumber) {
-      streetParts.push(streetNumber);
+    // Use placeName (e.g. hospital/landmark name) if not already captured as premise
+    const effectivePremise = premise || (placeName && placeName !== route ? placeName : "");
+    if (effectivePremise) streetParts.push(effectivePremise);
+
+    // Skip streetNumber + route if placeName already contains the route (avoids duplication
+    // e.g. "23 Thompson Ave, opposite British Council" + "23 Thompson Avenue")
+    const placeNameContainsRoute =
+      route &&
+      effectivePremise &&
+      effectivePremise.toLowerCase().includes(route.substring(0, 6).toLowerCase());
+
+    if (!placeNameContainsRoute) {
+      if (streetNumber && route) {
+        streetParts.push(`${streetNumber} ${route}`);
+      } else if (route) {
+        streetParts.push(route);
+      } else if (streetNumber) {
+        streetParts.push(streetNumber);
+      }
     }
     if (sublocalityLevel2) streetParts.push(sublocalityLevel2);
     if (sublocalityLevel1) streetParts.push(sublocalityLevel1);
@@ -357,18 +373,20 @@ export function AddressModal({
     try {
       const parameter = {
         placeId: placeId,
-        fields: ["address_components", "formatted_address"],
+        fields: ["address_components", "formatted_address", "name"],
       };
 
       const details = await getDetails(parameter);
 
       if (typeof details !== "string" && details.address_components) {
-        const parsed = parseAddressComponents(details.address_components);
+        const placeName = (details as google.maps.places.PlaceResult).name;
+        const parsed = parseAddressComponents(details.address_components, placeName);
 
         if (!isDeliveryLocationAllowed(parsed.state, parsed.city)) {
           toast.error(DELIVERY_RESTRICTION_MESSAGE);
         } else {
           setManualAddress((prev) => ({ ...prev, ...parsed }));
+          setShowExtraFields(true);
         }
 
         setSearchValue("");
@@ -584,6 +602,7 @@ export function AddressModal({
                 const sanitized = sanitizeStreetInput(e.target.value);
                 setManualAddress({ ...manualAddress, street: sanitized });
               }}
+              onFocus={() => setShowExtraFields(true)}
               placeholder="e.g., 123 Main Street"
               maxLength={ADDRESS_LIMITS.STREET_MAX_LENGTH + 50}
               className={`w-full px-3 py-2 border-2 rounded-xl text-sm focus:outline-none transition-colors ${
@@ -594,7 +613,7 @@ export function AddressModal({
             />
             {isStreetInvalid && (
               <p className="text-xs text-red-500 mt-1">
-                Only letters, numbers, and commas are allowed.
+                Only letters, numbers, commas, hyphens, periods, and slashes are allowed.
               </p>
             )}
             {isStreetTooLong && (
@@ -605,11 +624,18 @@ export function AddressModal({
             )}
           </div>
 
+          {/* Extra fields — revealed after street focus or Google selection */}
+          <div
+            className={`grid transition-all duration-500 ease-in-out ${showExtraFields ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}
+          >
+          <div className="overflow-hidden">
+          <div className="space-y-3 pt-1">
+
           {/* Apartment/House Number */}
           <div>
             <div className="flex justify-between items-center mb-1.5">
               <label className="block text-xs font-semibold text-gray-700">
-                Apartment/House Number
+                Apartment/House Number (Optional)
               </label>
               {manualAddress.apartment.length > 0 && (
                 <span
@@ -703,7 +729,9 @@ export function AddressModal({
             </Select>
           </div>
 
-      
+          </div>{/* end space-y-3 */}
+          </div>{/* end overflow-hidden */}
+          </div>{/* end grid transition wrapper */}
 
           {/* Submit Button */}
           <Button

--- a/src/pages/home/components/modals/PackageTypeModal.tsx
+++ b/src/pages/home/components/modals/PackageTypeModal.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { FiCheck } from "react-icons/fi";
 import { Button } from "@/components/ui/button";
 import packageIcon from "@/assets/icons/size.png";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 // Step Indicator Component (brand color and number for complete)
 const StepIndicator = ({ stepNumber, isComplete, isActive }: { stepNumber: number; isComplete: boolean; isActive: boolean }) => {
@@ -51,7 +51,7 @@ export function PackageTypeModal({
   onConfirm,
 }: PackageTypeModalProps) {
   const { data: packageTypes } = useGetPackageType({ minimize: true });
-  const packages = packageTypes?.data || [];
+  const packages = useMemo(() => packageTypes?.data || [], [packageTypes?.data]);
 
   const [selectedPackage, setSelectedPackage] = useState<any>(null);
   const [weight, setWeight] = useState("");
@@ -65,7 +65,9 @@ export function PackageTypeModal({
     parseFloat(length) > 0 && parseFloat(width) > 0 && parseFloat(height) > 0;
   const step2Complete = step1Complete && weight && parseFloat(weight) > 0 &&
     !(selectedPackage?.maxWeight && parseFloat(weight) > selectedPackage.maxWeight);
-  const step3Complete = step2Complete && itemPrice && parseFloat(itemPrice) > 0;
+  // itemPrice is optional — step 3 is complete as long as steps 1 & 2 are done
+  // const step3Complete = step2Complete && itemPrice && parseFloat(itemPrice) > 0;
+  const step3Complete = step2Complete;
 
   // Initialize from current values when modal opens
   useEffect(() => {
@@ -136,7 +138,7 @@ export function PackageTypeModal({
 
     const currentWeight = parseFloat(weight) || 0;
     const maxWeight = selectedPackage.maxWeight;
-    const price = parseFloat(itemPrice) || 0;
+    //const price = parseFloat(itemPrice) || 0;
 
     // Validate weight
     if (currentWeight <= 0) return;
@@ -147,7 +149,7 @@ export function PackageTypeModal({
     if (parseFloat(length) <= 0 || parseFloat(width) <= 0 || parseFloat(height) <= 0) return;
 
     // Validate item price
-    if (price <= 0) return;
+    //if (price <= 0) return;
 
     const formattedDimensions = `${length} × ${width} × ${height} ${selectedPackage.dimensionUnit}`;
 
@@ -319,7 +321,7 @@ export function PackageTypeModal({
                 </div>
               </div>
 
-              <div className="grid grid-cols-4 gap-2">
+              <div className="grid grid-cols-3 lg:grid-cols-4 gap-2">
                 {weightPresets.map((preset) => (
                   <button
                     key={preset.label}
@@ -349,7 +351,7 @@ export function PackageTypeModal({
             <StepIndicator stepNumber={3} isComplete={step3Complete} isActive={step2Complete && !step3Complete} />
 
             <div className="flex-1">
-              <h3 className={cn("font-semibold text-sm mb-3", step2Complete ? "text-gray-900" : "text-gray-400")}>How much is it worth?</h3>
+              <h3 className={cn("font-semibold text-sm mb-3", step2Complete ? "text-gray-900" : "text-gray-400")}>How much is it worth? (Optional)</h3>
 
               <label className={cn("block text-xs mb-3", step2Complete ? "text-gray-600" : "text-gray-400")}>
                 Item value for insurance coverage

--- a/src/utils/form-validators.ts
+++ b/src/utils/form-validators.ts
@@ -9,8 +9,8 @@ export const ADDRESS_LIMITS = {
   APARTMENT_MAX_LENGTH: 100,
 } as const;
 
-export const STREET_ALLOWED_REGEX = new RegExp("^[a-zA-Z0-9, ]+$");
-export const STREET_SANITIZE_REGEX = new RegExp("[^a-zA-Z0-9, ]", "g");
+export const STREET_ALLOWED_REGEX = new RegExp("^[a-zA-Z0-9,. \\-'/&]+$");
+export const STREET_SANITIZE_REGEX = new RegExp("[^a-zA-Z0-9,. \\-'/&]", "g");
 
 /**
  * Validates that a string contains only numbers and optional decimal point
@@ -130,7 +130,7 @@ export const validateManualAddress = (
   if (!STREET_ALLOWED_REGEX.test(street.trim())) {
     return {
       valid: false,
-      message: "Street address can only contain letters, numbers, and commas",
+      message: "Street address contains unsupported characters",
     };
   }
 


### PR DESCRIPTION
Modified address modal to hide some text field from the user until they confirm their actual addres from google search or manually entering their address.
We can now get the entire street name values directly from the google address suggestion.
Makde item value optional 