### PR TITLE
fix: add PostHog ingestion endpoints to Content Security Policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://maps.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://beta-api.gosendeet.com https://api.gosendeet.com https://maps.googleapis.com https://*.paystack.co https://*.paystack.com; frame-src https://checkout.paystack.com https://standard.paystack.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://maps.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://beta-api.gosendeet.com https://api.gosendeet.com https://maps.googleapis.com https://*.paystack.co https://*.paystack.com https://app.posthog.com https://us.i.posthog.com https://eu.i.posthog.com; frame-src https://checkout.paystack.com https://standard.paystack.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self';"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
CSP connect-src was blocking PostHog event captures in production. Added app.posthog.com, us.i.posthog.com, and eu.i.posthog.com — the SDK routes events to the *.i.posthog.com ingestion endpoints internally, which differ from the configured host.