### PR TITLE
fix: fix(security): resolve 5 frontend information-leak vulnerabilities

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -81,7 +81,7 @@ define(['./workbox-7e5eb42b'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.kf6pi63hsm4"
+    "revision": "0.jsqlf4f33no"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import PrivateRoutes from "./lib/PrivateRoutes";
 import PublicRoutes from "./lib/PublicRoutes";
 import AdminRoutes from "./lib/AdminRoutes";
 import FranchiseRoutes from "./lib/FranchiseRoutes";
+import BookingRoutes from "./lib/BookingRoutes";
 import ErrorPage from "./pages/home/CostCalculator/components/Calculator/Booking/ErrorPage";
 import PublicDispatchPage from "./pages/dispatch/PublicDispatchPage";
 import FranchiseLayout from "./layouts/FranchiseLayout";
@@ -46,11 +47,6 @@ const AppRoutes = () => {
           <Route path="/cost-calculator" element={<CostCalculator />} />
           <Route path="/faq" element={<FAQ />} />
           <Route path="/track" element={<Track />} />
-          <Route path="/delivery" element={<Delivery />} />
-          <Route path="/pickup-time" element={<PickupTime />} />
-          <Route path="/checkout" element={<Checkout />} />
-          <Route path="/success-page" element={<Confirmation />} />
-          <Route path="/error-page" element={<ErrorPage />} />
           <Route path="/track-booking" element={<Tracking />} />
           <Route path="/terms" element={<Terms />} />
           <Route path="/privacy" element={<Privacy />} />
@@ -67,6 +63,14 @@ const AppRoutes = () => {
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/:id/reset-password" element={<ResetPassword />} />
           <Route path="/oauth2/callback" element={<ValidateGoogleLogin />} />
+        </Route>
+
+        <Route element={<BookingRoutes />}>
+          <Route path="/delivery" element={<Delivery />} />
+          <Route path="/pickup-time" element={<PickupTime />} />
+          <Route path="/checkout" element={<Checkout />} />
+          <Route path="/success-page" element={<Confirmation />} />
+          <Route path="/error-page" element={<ErrorPage />} />
         </Route>
 
         <Route element={<PrivateRoutes />}>

--- a/src/hooks/useSessionSync.ts
+++ b/src/hooks/useSessionSync.ts
@@ -1,24 +1,29 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { clearAuthSession } from "@/lib/authSession";
+import { clearAuthSession, setupCrossTabSync } from "@/lib/authSession";
 
 /**
- * Listens for cross-tab session changes via the `storage` event.
- * When another tab clears the auth session (logout or token expiry),
- * this tab clears its own sessionStorage and redirects to sign-in.
+ * Handles cross-tab session lifecycle:
+ * - Responds to REQUEST_SESSION from new tabs (setupCrossTabSync)
+ * - Redirects to sign-in when another tab logs out (storage event)
  */
 export const useSessionSync = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    const cleanupCrossTabSync = setupCrossTabSync();
+
     const handleStorage = (event: StorageEvent) => {
-      if (event.key === "userId" && event.newValue === null) {
+      if (event.key === "authSession" && event.newValue === null) {
         clearAuthSession();
         navigate("/signin", { replace: true });
       }
     };
 
     window.addEventListener("storage", handleStorage);
-    return () => window.removeEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      cleanupCrossTabSync();
+    };
   }, [navigate]);
 };

--- a/src/lib/BookingRoutes.tsx
+++ b/src/lib/BookingRoutes.tsx
@@ -1,0 +1,13 @@
+import { Outlet, Navigate } from "react-router-dom";
+
+import { hasAuthSession } from "./authSession";
+
+const BookingRoutes = () => {
+  if (!hasAuthSession()) {
+    return <Navigate to="/signin" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default BookingRoutes;

--- a/src/lib/authSession.ts
+++ b/src/lib/authSession.ts
@@ -11,9 +11,21 @@ type SessionUser = {
 };
 
 const AUTH_SESSION_KEY = "authSession";
+const BROADCAST_CHANNEL_NAME = "auth_session_sync";
 
-// Keys that must be shared across tabs — stored in both localStorage and sessionStorage
-const AUTH_KEYS = [AUTH_SESSION_KEY, "userId", "role", "profileImage", "sessionExpired"] as const;
+// Keys written to sessionStorage (never to localStorage)
+const SESSION_ONLY_KEYS = ["userId", "role", "profileImage"] as const;
+// Keys written to both storages (presence flag + expiry signal)
+const LOCAL_STORAGE_KEYS = [AUTH_SESSION_KEY, "sessionExpired"] as const;
+const ALL_SESSION_KEYS = [...LOCAL_STORAGE_KEYS, ...SESSION_ONLY_KEYS] as const;
+
+const openChannel = (): BroadcastChannel | null => {
+  try {
+    return new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+  } catch {
+    return null;
+  }
+};
 
 const resolveProfileImage = (user: SessionUser) =>
   user.profilePicture ||
@@ -33,7 +45,7 @@ export const hasAuthSession = () =>
 export const storeAuthSession = (user: SessionUser) => {
   const profileImage = resolveProfileImage(user);
 
-  const items: Record<string, string | null> = {
+  const sessionItems: Record<string, string | null> = {
     [AUTH_SESSION_KEY]: "true",
     userId: String(user.id ?? ""),
     role: String(user.role ?? "").toLowerCase(),
@@ -41,38 +53,106 @@ export const storeAuthSession = (user: SessionUser) => {
     profileImage: profileImage || null,
   };
 
-  Object.entries(items).forEach(([key, value]) => {
+  // Write all data to sessionStorage only
+  Object.entries(sessionItems).forEach(([key, value]) => {
     if (value !== null) {
       sessionStorage.setItem(key, value);
-      localStorage.setItem(key, value);
     } else {
       sessionStorage.removeItem(key);
-      localStorage.removeItem(key);
     }
   });
+
+  // Only write presence flags to localStorage — never userId/role/profileImage
+  localStorage.setItem(AUTH_SESSION_KEY, "true");
+  localStorage.setItem("sessionExpired", "false");
 };
 
 export const clearAuthSession = () => {
-  AUTH_KEYS.forEach((key) => {
-    sessionStorage.removeItem(key);
-    localStorage.removeItem(key);
+  ALL_SESSION_KEYS.forEach((key) => sessionStorage.removeItem(key));
+  LOCAL_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
+};
+
+/**
+ * Requests session data from an existing tab via BroadcastChannel.
+ * Returns a Promise that resolves once sync completes or the 300ms window
+ * expires (meaning no existing tab is open — stale flag is cleared).
+ * Called once in main.tsx before first render so route guards see a
+ * populated sessionStorage on new-tab open.
+ */
+export const syncSessionFromStorage = (): Promise<void> => {
+  return new Promise((resolve) => {
+    if (sessionStorage.getItem("userId")) {
+      resolve();
+      return;
+    }
+
+    if (localStorage.getItem(AUTH_SESSION_KEY) !== "true") {
+      resolve();
+      return;
+    }
+
+    const channel = openChannel();
+    if (!channel) {
+      // BroadcastChannel unsupported — clear the stale flag and give up
+      localStorage.removeItem(AUTH_SESSION_KEY);
+      resolve();
+      return;
+    }
+
+    const done = () => {
+      try { channel.close(); } catch { /* ignore */ }
+      resolve();
+    };
+
+    // If no existing tab responds within 300ms the flag is stale
+    // (browser was closed without logout) — clear it and start fresh
+    const timeout = setTimeout(() => {
+      localStorage.removeItem(AUTH_SESSION_KEY);
+      done();
+    }, 300);
+
+    channel.onmessage = (event: MessageEvent) => {
+      if (event.data?.type === "SESSION_DATA") {
+        clearTimeout(timeout);
+        const { userId, role, profileImage } = event.data;
+        if (userId) {
+          sessionStorage.setItem(AUTH_SESSION_KEY, "true");
+          sessionStorage.setItem("userId", String(userId));
+          sessionStorage.setItem("role", String(role ?? ""));
+          if (profileImage) sessionStorage.setItem("profileImage", String(profileImage));
+          sessionStorage.setItem("sessionExpired", "false");
+        }
+        done();
+      }
+    };
+
+    channel.postMessage({ type: "REQUEST_SESSION" });
   });
 };
 
 /**
- * Copies auth keys from localStorage → sessionStorage.
- * Called once on app startup so new tabs inherit the active session.
+ * Registers this tab as a session data provider.
+ * When a new tab broadcasts REQUEST_SESSION, this tab replies with its
+ * sessionStorage data. Returns a cleanup function.
  */
-export const syncSessionFromStorage = () => {
-  if (sessionStorage.getItem("userId")) return; // Already populated
+export const setupCrossTabSync = (): (() => void) => {
+  const channel = openChannel();
+  if (!channel) return () => {};
 
-  const userId = localStorage.getItem("userId");
-  if (!userId) return; // No active session to sync
-
-  AUTH_KEYS.forEach((key) => {
-    const value = localStorage.getItem(key);
-    if (value !== null) {
-      sessionStorage.setItem(key, value);
+  const handler = (event: MessageEvent) => {
+    if (event.data?.type === "REQUEST_SESSION") {
+      const userId = sessionStorage.getItem("userId");
+      if (userId) {
+        channel.postMessage({
+          type: "SESSION_DATA",
+          userId,
+          role: sessionStorage.getItem("role") ?? "",
+          profileImage: sessionStorage.getItem("profileImage") ?? "",
+        });
+      }
     }
-  });
+  };
+
+  channel.addEventListener("message", handler);
+  return () => { try { channel.close(); } catch { /* ignore */ } };
 };

--- a/src/lib/errorHandling.ts
+++ b/src/lib/errorHandling.ts
@@ -1,5 +1,6 @@
 interface AxiosErrorShape {
   response?: {
+    status?: number;
     data?: unknown;
   };
 }
@@ -35,9 +36,19 @@ export const throwApiError = (
   fallbackMessage = "Something went wrong"
 ): never => {
   const axiosError = error as AxiosErrorShape;
+  const status = axiosError?.response?.status;
   const responseData = axiosError?.response?.data;
-  const fallback = extractMessage(error) || fallbackMessage;
-  const message = extractMessage(responseData) || fallback;
+
+  // 5xx and network errors (no status) may contain internal server details —
+  // never forward those to the UI; use the fallback instead.
+  const isServerError = !status || status >= 500;
+
+  if (isServerError) {
+    throw { message: fallbackMessage };
+  }
+
+  const message =
+    extractMessage(responseData) || extractMessage(error) || fallbackMessage;
 
   if (isRecord(responseData)) {
     throw { ...responseData, message };

--- a/src/lib/openWhatsAppSupport.ts
+++ b/src/lib/openWhatsAppSupport.ts
@@ -8,7 +8,9 @@ const SUPPORT_NUMBER = import.meta.env.VITE_SUPPORT_WHATSAPP ?? "";
  */
 const openWhatsAppSupport = (message?: string) => {
   if (!SUPPORT_NUMBER) {
-    console.warn("VITE_SUPPORT_WHATSAPP is not set in .env");
+    if (import.meta.env.DEV) {
+      console.warn("VITE_SUPPORT_WHATSAPP is not set in .env");
+    }
     return;
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,30 +4,32 @@ import "./index.css";
 import App from "./App.tsx";
 import { initAnalytics } from "./lib/analytics.ts";
 import { syncSessionFromStorage } from "./lib/authSession.ts";
-
-initAnalytics();
-syncSessionFromStorage();
 import { QueryClientProvider } from "@tanstack/react-query";
 import queryClient from "./lib/query.ts";
 import { Toaster } from "@/components/ui/sonner";
-import { LoadScriptNext } from "@react-google-maps/api"; // 👈 import LoadScript
+import { LoadScriptNext } from "@react-google-maps/api";
 import { Spinner } from "./components/Spinner/index.tsx";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <LoadScriptNext
-        googleMapsApiKey={import.meta.env.VITE_GOOGLE_MAPS_KEY} // 👈 Vite env
-        libraries={["places"]} // 👈 important for autocomplete
-        loadingElement={
-          <div className="h-[100vh] w-full flex items-center justify-center">
-            <Spinner />
-          </div>
-        } // 👈 custom loader
-      >
-        <App />
-      </LoadScriptNext>
-      <Toaster position="top-right" richColors />
-    </QueryClientProvider>
-  </StrictMode>
-);
+initAnalytics();
+
+const renderApp = () =>
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <LoadScriptNext
+          googleMapsApiKey={import.meta.env.VITE_GOOGLE_MAPS_KEY}
+          libraries={["places"]}
+          loadingElement={
+            <div className="h-[100vh] w-full flex items-center justify-center">
+              <Spinner />
+            </div>
+          }
+        >
+          <App />
+        </LoadScriptNext>
+        <Toaster position="top-right" richColors />
+      </QueryClientProvider>
+    </StrictMode>
+  );
+
+syncSessionFromStorage().then(renderApp);

--- a/src/pages/auth/Signup/index.tsx
+++ b/src/pages/auth/Signup/index.tsx
@@ -35,9 +35,7 @@ const Signup = () => {
   // remove showFranchiseForm or comment this out to revert to old logic
   const showFranchiseForm =
     import.meta.env.DEV ||
-    window.location.hostname
-      .toLowerCase()
-      .includes("gosendeet-beta.vercel.app");
+    import.meta.env.VITE_SHOW_FRANCHISE_FORM === "true";
   const skipEmailValidation = isNonProductionEmailValidationEnv();
   const [searchParams] = useSearchParams();
   const requestedUserType = getInitialUserType(searchParams.get("type"));

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,6 +8,7 @@ interface ImportMetaEnv {
   readonly VITE_SUPPORT_WHATSAPP?: string;
   readonly VITE_POSTHOG_KEY?: string;
   readonly VITE_POSTHOG_HOST?: string;
+  readonly VITE_SHOW_FRANCHISE_FORM?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
- Finding 1 (Critical): Move booking flow routes (/delivery,
  /pickup-time, /checkout, /success-page, /error-page) behind a
  synchronous BookingRoutes guard. Prior useEffect-based checks
  allowed a one-frame render of PII (sender name, phone, email)
  before redirect fired.

- Finding 2 (Medium): Replace hardcoded "gosendeet-beta.vercel.app"
  hostname check in Signup with VITE_SHOW_FRANCHISE_FORM env var.
  Staging URL no longer compiled into production bundle.

- Finding 3 (Medium): Gate throwApiError on HTTP status code. 5xx
  and network errors now return only the fallback message; raw
  server internals are never forwarded to toast notifications.

- Finding 4 (Medium): Remove userId, role, and profileImage from
  localStorage. Only a boolean presence flag is persisted. Cross-tab
  session sync migrated from localStorage reads to BroadcastChannel
  so new tabs still inherit active sessions. Stale flags are cleared
  after a 300ms timeout when no existing tab responds.

- Finding 5 (Low): Guard console.warn in openWhatsAppSupport with
  import.meta.env.DEV so the VITE_SUPPORT_WHATSAPP var name is not
  exposed in production DevTools.
